### PR TITLE
Enable selection & removal of history entries

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,4 @@
-import {Component, signal} from '@angular/core';
+import {Component, computed, inject, signal} from '@angular/core';
 import {Configuration} from './features/configuration/configuration';
 import {ResponseChart} from './features/response-chart/response-chart';
 import {LiveLogs} from './features/live-logs/live-logs';
@@ -6,6 +6,7 @@ import {History} from './features/history/history';
 import {HlmCardDirective} from '@spartan-ng/helm/card';
 import {LucideAngularModule} from 'lucide-angular';
 import {NgClass} from '@angular/common';
+import {BenchmarkHistoryService} from './core/services/benchmark-history.service';
 
 @Component({
   selector: 'app-root',
@@ -16,38 +17,34 @@ import {NgClass} from '@angular/common';
 export class App {
   protected readonly title = signal('RequestFetcher');
 
-  protected readonly infos = [
-    {
-      id: 1,
-      icon: 'clock',
-      title: 'Average',
-      value: '100ms',
-      colorIcon: 'text-orange-500 border border-orange-500',
-      color: 'text-orange-500'
-    },
-    {
-      id: 2,
-      icon: 'move-down',
-      title: 'Min',
-      value: '181ms',
-      colorIcon: '',
-      color: ''
-    },
-    {
-      id: 3,
-      icon: 'move-up',
-      title: 'Max',
-      value: '181ms',
-      colorIcon: '',
-      color: ''
-    },
-    {
-      id: 4,
-      icon: 'check',
-      title: 'Success',
-      value: '100%',
-      colorIcon: 'text-green-500 border border-green-500',
-      color: 'text-green-500'
+  private readonly history = inject(BenchmarkHistoryService);
+
+  protected readonly infos = computed(() => {
+    const result = this.history.selected();
+    const base = [
+      { id: 1, icon: 'clock', title: 'Average', colorIcon: 'text-orange-500 border border-orange-500', color: 'text-orange-500' },
+      { id: 2, icon: 'move-down', title: 'Min', colorIcon: '', color: '' },
+      { id: 3, icon: 'move-up', title: 'Max', colorIcon: '', color: '' },
+      { id: 4, icon: 'check', title: 'Success', colorIcon: 'text-green-500 border border-green-500', color: 'text-green-500' }
+    ];
+
+    if (!result) {
+      return base.map(info => ({ ...info, value: '-' }));
     }
-  ]
+
+    const success = this.calculateSuccessRate(result.durations);
+
+    return [
+      { ...base[0], value: `${result.averageTime}ms` },
+      { ...base[1], value: `${result.minTime}ms` },
+      { ...base[2], value: `${result.maxTime}ms` },
+      { ...base[3], value: `${success}%` }
+    ];
+  });
+
+  private calculateSuccessRate(durations: number[]): number {
+    if (!durations?.length) return 100;
+    const ok = durations.filter(d => d >= 0).length;
+    return Math.round((ok / durations.length) * 100);
+  }
 }

--- a/src/app/core/models/BenchmarkResult.model.ts
+++ b/src/app/core/models/BenchmarkResult.model.ts
@@ -7,4 +7,5 @@ export interface BenchmarkResult {
   minTime: number;
   maxTime: number;
   log: string[];
+  durations: number[];
 }

--- a/src/app/core/services/benchmark-history.service.ts
+++ b/src/app/core/services/benchmark-history.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, computed, signal } from '@angular/core';
+import { BenchmarkResult } from '../models/BenchmarkResult.model';
+
+@Injectable({ providedIn: 'root' })
+export class BenchmarkHistoryService {
+  private readonly resultsSignal = signal<BenchmarkResult[]>([]);
+  private readonly selectedSignal = signal<BenchmarkResult | null>(null);
+
+  readonly results = computed(() => this.resultsSignal());
+  readonly selected = computed(() => this.selectedSignal());
+
+  addResult(result: Omit<BenchmarkResult, 'id' | 'timestamp'>) {
+    const newResult: BenchmarkResult = {
+      ...result,
+      id: crypto.randomUUID(),
+      timestamp: new Date(),
+    };
+    this.resultsSignal.update(res => [newResult, ...res]);
+    this.selectedSignal.set(newResult);
+  }
+
+  clear() {
+    this.resultsSignal.set([]);
+    this.selectedSignal.set(null);
+  }
+
+  select(id: string) {
+    const found = this.resultsSignal().find(r => r.id === id) || null;
+    this.selectedSignal.set(found);
+  }
+
+  remove(id: string) {
+    this.resultsSignal.update(res => res.filter(r => r.id !== id));
+    const sel = this.selectedSignal();
+    if (sel && sel.id === id) {
+      this.selectedSignal.set(null);
+    }
+  }
+}

--- a/src/app/features/history/history.html
+++ b/src/app/features/history/history.html
@@ -13,7 +13,7 @@
       @for (result of benchmarkResults(); track result.id) {
         <div hlmCard class="history-item">
           <div class="request-header">
-            <button hlmBtn size="icon" variant="ghost">
+            <button hlmBtn size="icon" variant="ghost" (click)="selectResult(result.id)">
               <lucide-icon name="external-link" size="20"></lucide-icon>
             </button>
             <span hlmBadge>{{ result.requests }} reqs</span>
@@ -22,6 +22,9 @@
             <input hlmInput type="text" placeholder="{{ result.url }}" readonly/>
             <button hlmBtn size="icon" variant="outline">
               <lucide-icon name="copy" size="20"></lucide-icon>
+            </button>
+            <button hlmBtn size="icon" variant="ghost" (click)="removeResult(result.id)">
+              <lucide-icon name="trash" size="20"></lucide-icon>
             </button>
           </div>
           <span>Avg: {{ result.averageTime }}ms</span>

--- a/src/app/features/history/history.ts
+++ b/src/app/features/history/history.ts
@@ -1,10 +1,11 @@
-import {Component, signal} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {HlmCardImports} from '@spartan-ng/helm/card';
 import {BenchmarkResult} from '../../core/models/BenchmarkResult.model';
 import {LucideAngularModule} from 'lucide-angular';
 import {HlmBadgeImports} from '@spartan-ng/helm/badge';
 import {HlmButtonDirective} from '@spartan-ng/helm/button';
 import {HlmInputDirective} from '@spartan-ng/helm/input';
+import {BenchmarkHistoryService} from '../../core/services/benchmark-history.service';
 
 @Component({
   selector: 'history',
@@ -19,19 +20,23 @@ import {HlmInputDirective} from '@spartan-ng/helm/input';
   styleUrl: './history.css'
 })
 export class History {
-  benchmarkResults = signal<BenchmarkResult[]>([]);
+  private readonly history = inject(BenchmarkHistoryService);
+
+  readonly benchmarkResults = this.history.results;
 
   addBenchmarkResult(result: Omit<BenchmarkResult, 'id' | 'timestamp'>): void {
-    const newResult: BenchmarkResult = {
-      ...result,
-      id: crypto.randomUUID(),
-      timestamp: new Date()
-    };
-
-    this.benchmarkResults.update(results => [newResult, ...results]);
+    this.history.addResult(result);
   }
 
   clearHistory(): void {
-    this.benchmarkResults.set([]);
+    this.history.clear();
+  }
+
+  selectResult(id: string): void {
+    this.history.select(id);
+  }
+
+  removeResult(id: string): void {
+    this.history.remove(id);
   }
 }

--- a/src/app/features/live-logs/live-logs.html
+++ b/src/app/features/live-logs/live-logs.html
@@ -4,7 +4,12 @@
     <h2 hlmCardHeader>System Log</h2>
   </header>
   <div class="log-window" hlmCardContent>
-    <div>> Server gestartet.</div>
-    <div>> Warten auf Eingaben...</div>
+    @if (selectedResult() && selectedResult()!.log.length) {
+      @for (entry of selectedResult()!.log; track $index) {
+        <div>{{ entry }}</div>
+      }
+    } @else {
+      <div class="text-muted-foreground">No log entries</div>
+    }
   </div>
 </section>

--- a/src/app/features/live-logs/live-logs.ts
+++ b/src/app/features/live-logs/live-logs.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {HlmCardDirective, HlmCardHeaderDirective, HlmCardImports} from '@spartan-ng/helm/card';
 import {LucideAngularModule} from 'lucide-angular';
+import {BenchmarkHistoryService} from '../../core/services/benchmark-history.service';
 
 @Component({
   selector: 'live-logs',
@@ -14,5 +15,7 @@ import {LucideAngularModule} from 'lucide-angular';
   styleUrl: './live-logs.css'
 })
 export class LiveLogs {
+  private readonly history = inject(BenchmarkHistoryService);
 
+  readonly selectedResult = this.history.selected;
 }

--- a/src/app/features/response-chart/response-chart.ts
+++ b/src/app/features/response-chart/response-chart.ts
@@ -1,8 +1,9 @@
-import {Component, signal} from '@angular/core';
+import {Component, computed, inject, signal} from '@angular/core';
 import {HlmCardImports} from '@spartan-ng/helm/card';
 import {NgxEchartsDirective} from 'ngx-echarts';
 import {EChartsOption} from 'echarts';
 import {getCssVariableValue} from '../../shared/utils/css-vars.util';
+import {BenchmarkHistoryService} from '../../core/services/benchmark-history.service';
 
 @Component({
   selector: 'response-chart',
@@ -14,7 +15,28 @@ import {getCssVariableValue} from '../../shared/utils/css-vars.util';
   styleUrl: './response-chart.css'
 })
 export class ResponseChart {
-  protected readonly chartsOptions = signal(this.initOptions());
+  private readonly history = inject(BenchmarkHistoryService);
+
+  protected readonly chartsOptions = computed(() => {
+    const result = this.history.selected();
+    const opts = this.initOptions();
+    if (!result || !result.durations?.length) return opts;
+    opts.series = [
+      {
+        name: 'Response Time',
+        type: 'line',
+        smooth: true,
+        data: result.durations.map((d, i) => [i + 1, d]),
+        symbol: 'circle',
+        symbolSize: 6,
+        lineStyle: {
+          width: 2,
+          color: '#2b7fff'
+        }
+      }
+    ];
+    return opts;
+  });
 
   initOptions(): EChartsOption {
     return {


### PR DESCRIPTION
## Summary
- add `BenchmarkHistoryService` to manage history records
- allow selecting and deleting history items
- show selected run data in logs, chart and info cards
- update `BenchmarkResult` model with `durations`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff7afabc8832c822792f7633ce3b5