### PR TITLE
Add history loading and deletion

### DIFF
--- a/src/app/core/services/benchmark-history.service.ts
+++ b/src/app/core/services/benchmark-history.service.ts
@@ -21,6 +21,11 @@ export class BenchmarkHistoryService {
     this.persist();
   }
 
+  remove(timestamp: string): void {
+    this.historySignal.update(h => h.filter(run => run.timestamp !== timestamp));
+    this.persist();
+  }
+
   private persist(): void {
     localStorage.setItem('benchmarkHistory', JSON.stringify(this.historySignal()));
   }

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, signal } from '@angular/core';
+import { RequestConfiguration } from '../models/RequestConfiguration.model';
+
+@Injectable({ providedIn: 'root' })
+export class ConfigService {
+  readonly targetUrl = signal('');
+  readonly requests = signal(20);
+  readonly interval = signal(1);
+  readonly asyncMode = signal(false);
+  readonly warmupRequest = signal(true);
+
+  getConfiguration(): RequestConfiguration {
+    return {
+      targetUrl: this.targetUrl(),
+      requests: this.requests(),
+      interval: this.interval(),
+      asyncMode: this.asyncMode(),
+      warmupRequest: this.warmupRequest(),
+    };
+  }
+
+  setConfiguration(config: RequestConfiguration): void {
+    this.targetUrl.set(config.targetUrl);
+    this.requests.set(config.requests);
+    this.interval.set(config.interval);
+    this.asyncMode.set(config.asyncMode);
+    this.warmupRequest.set(config.warmupRequest);
+  }
+}

--- a/src/app/features/configuration/configuration.ts
+++ b/src/app/features/configuration/configuration.ts
@@ -1,4 +1,4 @@
-import {Component, signal, inject} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {HlmLabelDirective} from '@spartan-ng/helm/label';
 import {HlmButtonDirective} from '@spartan-ng/helm/button';
 import {HlmInputDirective} from '@spartan-ng/helm/input';
@@ -7,6 +7,7 @@ import {HlmSwitchImports} from '@spartan-ng/helm/switch';
 import {HlmCardImports} from '@spartan-ng/helm/card';
 import {LucideAngularModule} from 'lucide-angular';
 import { BenchmarkService } from '../../core/services/benchmark.service';
+import { ConfigService } from '../../core/services/config.service';
 
 @Component({
   selector: 'configuration',
@@ -25,12 +26,13 @@ import { BenchmarkService } from '../../core/services/benchmark.service';
 })
 export class Configuration {
   private readonly benchmark = inject(BenchmarkService);
+  private readonly config = inject(ConfigService);
 
-  targetUrl = signal<string>('');
-  requests = signal(20);
-  interval = signal(1);
-  asyncMode = signal(false);
-  warmupRequest = signal(true);
+  targetUrl = this.config.targetUrl;
+  requests = this.config.requests;
+  interval = this.config.interval;
+  asyncMode = this.config.asyncMode;
+  warmupRequest = this.config.warmupRequest;
 
   readonly isRunning = this.benchmark.isRunning;
 
@@ -49,16 +51,7 @@ export class Configuration {
 
   startBenchmark(): void {
     if (!this.isValidConfiguration()) return;
-
-    const config = {
-      targetUrl: this.targetUrl(),
-      requests: this.requests(),
-      interval: this.interval(),
-      asyncMode: this.asyncMode(),
-      warmupRequest: this.warmupRequest()
-    };
-
-    this.benchmark.startBenchmark(config);
+    this.benchmark.startBenchmark(this.config.getConfiguration());
   }
 }
 

--- a/src/app/features/history/history.css
+++ b/src/app/features/history/history.css
@@ -40,6 +40,16 @@
   gap: .5rem;
   align-items: flex-start;
   padding: 1rem;
+  cursor: pointer;
+  transition: background-color .2s;
+
+  &:hover {
+    background-color: var(--color-gray-50);
+
+    .request-header button {
+      visibility: visible;
+    }
+  }
 
   .request-header {
     display: flex;
@@ -47,6 +57,10 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
+
+    button {
+      visibility: hidden;
+    }
   }
 
   .request-info {

--- a/src/app/features/history/history.html
+++ b/src/app/features/history/history.html
@@ -11,9 +11,12 @@
   <div hlmCardContent class="history-content">
     <div class="history-list">
       @for (run of benchmarkResults(); track run.timestamp) {
-        <div hlmCard class="history-item">
+        <div hlmCard class="history-item" (click)="loadRun(run)">
           <div class="request-header">
             <span hlmBadge>{{ run.config.requests }} reqs</span>
+            <button hlmBtn variant="ghost" size="icon" (click)="deleteRun(run.timestamp); $event.stopPropagation()">
+              <lucide-icon name="trash" size="16"></lucide-icon>
+            </button>
           </div>
           <div class="request-info">
             <input hlmInput type="text" placeholder="{{ run.config.targetUrl }}" readonly />

--- a/src/app/features/history/history.ts
+++ b/src/app/features/history/history.ts
@@ -6,6 +6,7 @@ import {HlmButtonDirective} from '@spartan-ng/helm/button';
 import {HlmInputDirective} from '@spartan-ng/helm/input';
 import { BenchmarkHistoryService } from '../../core/services/benchmark-history.service';
 import { BenchmarkRun } from '../../core/models/BenchmarkRun.model';
+import { BenchmarkService } from '../../core/services/benchmark.service';
 
 @Component({
   selector: 'history',
@@ -21,10 +22,19 @@ import { BenchmarkRun } from '../../core/models/BenchmarkRun.model';
 })
 export class History {
   private readonly historyService = inject(BenchmarkHistoryService);
+  private readonly benchmark = inject(BenchmarkService);
   benchmarkResults = this.historyService.history;
 
   clearHistory(): void {
     this.historyService.clear();
+  }
+
+  loadRun(run: BenchmarkRun): void {
+    this.benchmark.loadRun(run);
+  }
+
+  deleteRun(timestamp: string): void {
+    this.historyService.remove(timestamp);
   }
 
   average(run: BenchmarkRun): number {

--- a/src/app/features/response-chart/response-chart.ts
+++ b/src/app/features/response-chart/response-chart.ts
@@ -20,9 +20,9 @@ export class ResponseChart {
   chartsOptions = computed(() => {
     const data = this.benchmark.durations().map((d, i) => {
       if (d === -1) {
-        return {value: [i + 1, 0], itemStyle: {color: '#ef4444'}};
+        return { value: [i + 1, 0], itemStyle: { color: '#ef4444' }, error: true };
       }
-      return {value: [i + 1, d]};
+      return { value: [i + 1, d] };
     });
     const options = this.baseOptions();
     if (Array.isArray(options.series)) {
@@ -76,7 +76,16 @@ export class ResponseChart {
         trigger: "axis",
         formatter: (params: any) => {
           if (!Array.isArray(params)) return '';
-          return params.map(p => `<b>${p.axisValue}</b> Request | <b>${p.data[1]}</b> ms`).join('<br/>');
+          return params
+            .map(p => {
+              const value = Array.isArray(p.value)
+                ? p.value[1]
+                : Array.isArray(p.data)
+                  ? p.data[1]
+                  : p.data?.value?.[1];
+              return `<b>${p.axisValue}</b> Request | <b>${p.data?.error ? 'error' : value}</b>${p.data?.error ? '' : ' ms'}`;
+            })
+            .join('<br/>');
         }
       },
       dataZoom: [


### PR DESCRIPTION
## Summary
- implement a `ConfigService` to share configuration state
- update `BenchmarkService` with `loadRun` and use `ConfigService`
- allow deleting single history entries and loading runs on click
- update chart tooltip to show `error` when a request failed

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff912ab54832cb07d159b31177b78