### PR TITLE
Remove async mode and add HTTP method config

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -8,11 +8,11 @@
       <article hlmCard class="info-card">
         <div class="flex gap-4 items-center">
           @if (info.icon) {
-            <lucide-icon [ngClass]="info.colorIcon" [name]="info.icon" size="20"></lucide-icon>
+            <lucide-icon [ngClass]="info.colorIcon" [ngStyle]="info.style" [name]="info.icon" size="20"></lucide-icon>
           }
-          <h3 [ngClass]="info.color">{{ info.title }}</h3>
+          <h3 [ngClass]="info.color" [ngStyle]="info.style">{{ info.title }}</h3>
         </div>
-        <p [ngClass]="info.color" class="font-semibold">{{ info.value }}</p>
+        <p [ngClass]="info.color" [ngStyle]="info.style" class="font-semibold">{{ info.value }}</p>
       </article>
     }
   </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -58,10 +58,14 @@ export class App {
     ];
   });
 
-  private successStyle(rate: number): string {
+  private successStyle(rate: number): Record<string, string> {
     const clamped = Math.max(0, Math.min(100, rate));
-    const r = Math.round(255 - (clamped * 2.55));
+    const r = Math.round(255 - clamped * 2.55);
     const g = Math.round(clamped * 2.55);
-    return `color: rgb(${r}, ${g}, 0); border-color: rgb(${r}, ${g}, 0)`;
+    const color = `rgb(${r}, ${g}, 0)`;
+    return {
+      color,
+      'border-color': color
+    };
   }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -51,9 +51,17 @@ export class App {
         icon: 'check',
         title: 'Success',
         value: `${stats.successRate.toFixed(0)}%`,
-        colorIcon: 'text-green-500 border border-green-500',
-        color: 'text-green-500'
+        colorIcon: '',
+        color: '',
+        style: this.successStyle(stats.successRate)
       }
     ];
   });
+
+  private successStyle(rate: number): string {
+    const clamped = Math.max(0, Math.min(100, rate));
+    const r = Math.round(255 - (clamped * 2.55));
+    const g = Math.round(clamped * 2.55);
+    return `color: rgb(${r}, ${g}, 0); border-color: rgb(${r}, ${g}, 0)`;
+  }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -5,12 +5,12 @@ import {LiveLogs} from './features/live-logs/live-logs';
 import {History} from './features/history/history';
 import {HlmCardDirective} from '@spartan-ng/helm/card';
 import {LucideAngularModule} from 'lucide-angular';
-import {NgClass} from '@angular/common';
-import { BenchmarkService } from './core/services/benchmark.service';
+import {NgClass, NgStyle} from '@angular/common';
+import {BenchmarkService} from './core/services/benchmark.service';
 
 @Component({
   selector: 'app-root',
-  imports: [Configuration, ResponseChart, LiveLogs, History, HlmCardDirective, LucideAngularModule, NgClass],
+  imports: [Configuration, ResponseChart, LiveLogs, History, HlmCardDirective, LucideAngularModule, NgClass, NgStyle],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
@@ -59,13 +59,7 @@ export class App {
   });
 
   private successStyle(rate: number): Record<string, string> {
-    const clamped = Math.max(0, Math.min(100, rate));
-    const r = Math.round(255 - clamped * 2.55);
-    const g = Math.round(clamped * 2.55);
-    const color = `rgb(${r}, ${g}, 0)`;
-    return {
-      color,
-      'border-color': color
-    };
+    const color = rate < 50 ? 'red' : rate < 75 ? 'orange' : '#0fc400';
+    return {color, 'border-color': color};
   }
 }

--- a/src/app/core/models/RequestConfiguration.model.ts
+++ b/src/app/core/models/RequestConfiguration.model.ts
@@ -1,6 +1,7 @@
 export interface RequestConfiguration {
   targetUrl: string;
   method: string;
+  customCode: string;
   requests: number;
   interval: number;
   warmupRequest: boolean;

--- a/src/app/core/models/RequestConfiguration.model.ts
+++ b/src/app/core/models/RequestConfiguration.model.ts
@@ -1,7 +1,7 @@
 export interface RequestConfiguration {
   targetUrl: string;
+  method: string;
   requests: number;
   interval: number;
-  asyncMode: boolean;
   warmupRequest: boolean;
 }

--- a/src/app/core/services/benchmark.service.ts
+++ b/src/app/core/services/benchmark.service.ts
@@ -43,7 +43,10 @@ export class BenchmarkService {
     if (config.warmupRequest) {
       try {
         await firstValueFrom(
-          this.http.get(config.targetUrl, { responseType: 'text', observe: 'response' })
+          this.http.request(config.method, config.targetUrl, {
+            responseType: 'text',
+            observe: 'response'
+          })
         );
         this.appendLog('> Warmup erfolgreich');
       } catch (err: any) {
@@ -56,7 +59,10 @@ export class BenchmarkService {
       const start = performance.now();
       try {
         await firstValueFrom(
-          this.http.get(config.targetUrl, { responseType: 'text', observe: 'response' })
+          this.http.request(config.method, config.targetUrl, {
+            responseType: 'text',
+            observe: 'response'
+          })
         );
         const dur = Math.round(performance.now() - start);
         this.updateDuration(index, dur);
@@ -68,20 +74,10 @@ export class BenchmarkService {
       }
     };
 
-    if (config.asyncMode) {
-      await Promise.all(
-        Array.from({ length: config.requests }).map((_, i) =>
-          new Promise<void>(resolve =>
-            setTimeout(() => executeRequest(i).then(resolve), i * config.interval * 1000)
-          )
-        )
-      );
-    } else {
-      for (let i = 0; i < config.requests; i++) {
-        await executeRequest(i);
-        if (i < config.requests - 1) {
-          await new Promise(res => setTimeout(res, config.interval * 1000));
-        }
+    for (let i = 0; i < config.requests; i++) {
+      await executeRequest(i);
+      if (i < config.requests - 1) {
+        await new Promise(res => setTimeout(res, config.interval * 1000));
       }
     }
 

--- a/src/app/core/services/benchmark.service.ts
+++ b/src/app/core/services/benchmark.service.ts
@@ -41,7 +41,14 @@ export class BenchmarkService {
     this.logSignal.set([]);
 
     const code = config.customCode?.trim();
-    const customFn = code ? new Function('http', 'config', 'index', code) : null;
+    const customFn = code
+      ? new Function(
+          'http',
+          'config',
+          'index',
+          `return (async () => { ${code} })();`
+        )
+      : null;
 
     if (config.warmupRequest) {
       try {

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -5,6 +5,7 @@ import { RequestConfiguration } from '../models/RequestConfiguration.model';
 export class ConfigService {
   readonly targetUrl = signal('');
   readonly method = signal('GET');
+  readonly customCode = signal('');
   readonly requests = signal(20);
   readonly interval = signal(1);
   readonly warmupRequest = signal(true);
@@ -13,6 +14,7 @@ export class ConfigService {
     return {
       targetUrl: this.targetUrl(),
       method: this.method(),
+      customCode: this.customCode(),
       requests: this.requests(),
       interval: this.interval(),
       warmupRequest: this.warmupRequest(),
@@ -22,6 +24,7 @@ export class ConfigService {
   setConfiguration(config: RequestConfiguration): void {
     this.targetUrl.set(config.targetUrl);
     this.method.set(config.method);
+    this.customCode.set(config.customCode);
     this.requests.set(config.requests);
     this.interval.set(config.interval);
     this.warmupRequest.set(config.warmupRequest);

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -4,26 +4,26 @@ import { RequestConfiguration } from '../models/RequestConfiguration.model';
 @Injectable({ providedIn: 'root' })
 export class ConfigService {
   readonly targetUrl = signal('');
+  readonly method = signal('GET');
   readonly requests = signal(20);
   readonly interval = signal(1);
-  readonly asyncMode = signal(false);
   readonly warmupRequest = signal(true);
 
   getConfiguration(): RequestConfiguration {
     return {
       targetUrl: this.targetUrl(),
+      method: this.method(),
       requests: this.requests(),
       interval: this.interval(),
-      asyncMode: this.asyncMode(),
       warmupRequest: this.warmupRequest(),
     };
   }
 
   setConfiguration(config: RequestConfiguration): void {
     this.targetUrl.set(config.targetUrl);
+    this.method.set(config.method);
     this.requests.set(config.requests);
     this.interval.set(config.interval);
-    this.asyncMode.set(config.asyncMode);
     this.warmupRequest.set(config.warmupRequest);
   }
 }

--- a/src/app/features/configuration/configuration.css
+++ b/src/app/features/configuration/configuration.css
@@ -56,3 +56,9 @@
   align-items: center;
   width: 100%;
 }
+
+.custom-editor textarea {
+  width: 100%;
+  min-height: 8rem;
+  font-family: monospace;
+}

--- a/src/app/features/configuration/configuration.html
+++ b/src/app/features/configuration/configuration.html
@@ -47,13 +47,16 @@
       </div>
     </div>
 
-    <!-- Async Mode Toggle -->
-    <div class="toggle-field">
-      <label hlmLabel for="async-mode">Async Mode</label>
-      <hlm-switch
-        id="async-mode"
-        [(ngModel)]="asyncMode"
-      ></hlm-switch>
+    <!-- HTTP Method -->
+    <div class="form-field">
+      <label hlmLabel for="method">HTTP Method</label>
+      <input
+        hlmInput
+        id="method"
+        type="text"
+        [(ngModel)]="method"
+        placeholder="GET"
+      />
     </div>
 
     <!-- Warm-up Request Toggle -->

--- a/src/app/features/configuration/configuration.html
+++ b/src/app/features/configuration/configuration.html
@@ -69,7 +69,11 @@
     <!-- Custom JS Editor -->
     <div class="form-field custom-editor" *ngIf="showCustom">
       <label hlmLabel for="custom-code">Request Code</label>
-      <textarea id="custom-code" [(ngModel)]="customCode" placeholder="http.request(method, targetUrl).toPromise()"></textarea>
+      <textarea
+        id="custom-code"
+        [(ngModel)]="customCode"
+        placeholder="await http.request(method, targetUrl).toPromise();"
+      ></textarea>
     </div>
 
     <!-- Warm-up Request Toggle -->

--- a/src/app/features/configuration/configuration.html
+++ b/src/app/features/configuration/configuration.html
@@ -50,13 +50,26 @@
     <!-- HTTP Method -->
     <div class="form-field">
       <label hlmLabel for="method">HTTP Method</label>
-      <input
-        hlmInput
-        id="method"
-        type="text"
-        [(ngModel)]="method"
-        placeholder="GET"
-      />
+      <select hlmInput id="method" [(ngModel)]="method">
+        <option>GET</option>
+        <option>POST</option>
+        <option>PUT</option>
+        <option>PATCH</option>
+        <option>DELETE</option>
+        <option>HEAD</option>
+        <option>OPTIONS</option>
+      </select>
+    </div>
+
+    <!-- Custom JS Toggle -->
+    <div class="form-field">
+      <button hlmBtn variant="outline" (click)="toggleCustom()">Custom JS</button>
+    </div>
+
+    <!-- Custom JS Editor -->
+    <div class="form-field custom-editor" *ngIf="showCustom">
+      <label hlmLabel for="custom-code">Request Code</label>
+      <textarea id="custom-code" [(ngModel)]="customCode" placeholder="http.request(method, targetUrl).toPromise()"></textarea>
     </div>
 
     <!-- Warm-up Request Toggle -->

--- a/src/app/features/configuration/configuration.ts
+++ b/src/app/features/configuration/configuration.ts
@@ -30,21 +30,25 @@ export class Configuration {
 
   targetUrl = this.config.targetUrl;
   method = this.config.method;
+  customCode = this.config.customCode;
   requests = this.config.requests;
   interval = this.config.interval;
   warmupRequest = this.config.warmupRequest;
+
+  showCustom = false;
 
   readonly isRunning = this.benchmark.isRunning;
 
   isValidConfiguration(): boolean {
     const url = this.targetUrl();
     const method = this.method().trim();
+    const code = this.customCode().trim();
     const reqs = this.requests();
     const int = this.interval();
 
     try {
       new URL(url);
-      return reqs > 0 && int > 0 && method.length > 0;
+      return reqs > 0 && int > 0 && (method.length > 0 || code.length > 0);
     } catch {
       return false;
     }
@@ -53,6 +57,10 @@ export class Configuration {
   startBenchmark(): void {
     if (!this.isValidConfiguration()) return;
     this.benchmark.startBenchmark(this.config.getConfiguration());
+  }
+
+  toggleCustom(): void {
+    this.showCustom = !this.showCustom;
   }
 }
 

--- a/src/app/features/configuration/configuration.ts
+++ b/src/app/features/configuration/configuration.ts
@@ -29,21 +29,22 @@ export class Configuration {
   private readonly config = inject(ConfigService);
 
   targetUrl = this.config.targetUrl;
+  method = this.config.method;
   requests = this.config.requests;
   interval = this.config.interval;
-  asyncMode = this.config.asyncMode;
   warmupRequest = this.config.warmupRequest;
 
   readonly isRunning = this.benchmark.isRunning;
 
   isValidConfiguration(): boolean {
     const url = this.targetUrl();
+    const method = this.method().trim();
     const reqs = this.requests();
     const int = this.interval();
 
     try {
       new URL(url);
-      return reqs > 0 && int > 0;
+      return reqs > 0 && int > 0 && method.length > 0;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary
- remove async mode support from configuration and benchmark service
- allow configuring the HTTP method for requests
- adjust configuration form to include method input

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ffab13708832c81f2eb0429d1b6bf