### PR TITLE
Add resumeable benchmark runs

### DIFF
--- a/src/app/core/services/benchmark-history.service.ts
+++ b/src/app/core/services/benchmark-history.service.ts
@@ -26,6 +26,15 @@ export class BenchmarkHistoryService {
     this.persist();
   }
 
+  getRun(timestamp: string): BenchmarkRun | undefined {
+    return this.historySignal().find(r => r.timestamp === timestamp);
+  }
+
+  updateRun(updated: BenchmarkRun): void {
+    this.historySignal.update(h => h.map(r => r.timestamp === updated.timestamp ? updated : r));
+    this.persist();
+  }
+
   private persist(): void {
     localStorage.setItem('benchmarkHistory', JSON.stringify(this.historySignal()));
   }

--- a/src/app/features/configuration/configuration.html
+++ b/src/app/features/configuration/configuration.html
@@ -88,16 +88,37 @@
       ></hlm-switch>
     </div>
 
-    <!-- Start Button -->
+    <!-- Control Buttons -->
     <button
       hlmBtn
       class="submit-button"
       variant="default"
       (click)="startBenchmark()"
-      [disabled]="(isRunning() || !isValidConfiguration())"
+      *ngIf="!isRunning() && !pendingRun"
+      [disabled]="!isValidConfiguration()"
     >
       <lucide-icon name="play" size="20"></lucide-icon>
       Start Requests
+    </button>
+    <button
+      hlmBtn
+      class="submit-button"
+      variant="outline"
+      (click)="stopBenchmark()"
+      *ngIf="isRunning()"
+    >
+      <lucide-icon name="stop" size="20"></lucide-icon>
+      Stop
+    </button>
+    <button
+      hlmBtn
+      class="submit-button"
+      variant="default"
+      (click)="continueBenchmark()"
+      *ngIf="!isRunning() && pendingRun"
+    >
+      <lucide-icon name="play" size="20"></lucide-icon>
+      Continue
     </button>
   </div>
 </section>

--- a/src/app/features/configuration/configuration.ts
+++ b/src/app/features/configuration/configuration.ts
@@ -1,4 +1,4 @@
-import {Component, inject} from '@angular/core';
+import {Component, inject, effect} from '@angular/core';
 import {HlmLabelDirective} from '@spartan-ng/helm/label';
 import {HlmButtonDirective} from '@spartan-ng/helm/button';
 import {HlmInputDirective} from '@spartan-ng/helm/input';
@@ -8,6 +8,7 @@ import {HlmCardImports} from '@spartan-ng/helm/card';
 import {LucideAngularModule} from 'lucide-angular';
 import { BenchmarkService } from '../../core/services/benchmark.service';
 import { ConfigService } from '../../core/services/config.service';
+import {ActivatedRoute, Router} from '@angular/router';
 
 @Component({
   selector: 'configuration',
@@ -27,6 +28,8 @@ import { ConfigService } from '../../core/services/config.service';
 export class Configuration {
   private readonly benchmark = inject(BenchmarkService);
   private readonly config = inject(ConfigService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   targetUrl = this.config.targetUrl;
   method = this.config.method;
@@ -38,6 +41,18 @@ export class Configuration {
   showCustom = false;
 
   readonly isRunning = this.benchmark.isRunning;
+  readonly currentRun = this.benchmark.currentRun;
+  get pendingRun(): string | null {
+    return this.route.snapshot.queryParamMap.get('run');
+  }
+
+  constructor() {
+    effect(() => {
+      if (!this.isRunning() && !this.currentRun()) {
+        this.router.navigate([], { queryParams: { run: null }, queryParamsHandling: 'merge' });
+      }
+    });
+  }
 
   isValidConfiguration(): boolean {
     const url = this.targetUrl();
@@ -56,7 +71,21 @@ export class Configuration {
 
   startBenchmark(): void {
     if (!this.isValidConfiguration()) return;
-    this.benchmark.startBenchmark(this.config.getConfiguration());
+    const ts = this.benchmark.startBenchmark(this.config.getConfiguration());
+    if (ts) {
+      this.router.navigate([], { queryParams: { run: ts }, queryParamsHandling: 'merge' });
+    }
+  }
+
+  stopBenchmark(): void {
+    this.benchmark.stopBenchmark();
+  }
+
+  continueBenchmark(): void {
+    const ts = this.pendingRun;
+    if (ts) {
+      this.benchmark.continueBenchmark(ts);
+    }
   }
 
   toggleCustom(): void {

--- a/src/app/features/history/history.html
+++ b/src/app/features/history/history.html
@@ -20,6 +20,7 @@
           </div>
           <div class="request-info">
             <input hlmInput type="text" placeholder="{{ run.config.targetUrl }}" readonly />
+            <lucide-icon [name]="hasErrors(run) ? 'x' : 'check'" [ngClass]="hasErrors(run) ? 'text-red-500' : 'text-green-500'" size="16"></lucide-icon>
           </div>
           <span>Avg: {{ average(run) }}ms</span>
         </div>

--- a/src/app/features/history/history.ts
+++ b/src/app/features/history/history.ts
@@ -42,4 +42,8 @@ export class History {
     if (!success.length) return 0;
     return Math.round(success.reduce((a, b) => a + b, 0) / success.length);
   }
+
+  hasErrors(run: BenchmarkRun): boolean {
+    return run.results.some(r => r === -1);
+  }
 }


### PR DESCRIPTION
## Summary
- persist benchmark progress in local storage and query param
- add stop and continue controls in configuration panel
- show error indicator in history

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880044bfef4832ca928bc8ac13f5ccf