### PR TITLE
Add custom header configuration

### DIFF
--- a/src/app/core/models/RequestConfiguration.model.ts
+++ b/src/app/core/models/RequestConfiguration.model.ts
@@ -1,7 +1,8 @@
 export interface RequestConfiguration {
   targetUrl: string;
   method: string;
-  customCode: string;
+  headerName: string;
+  headerValue: string;
   requests: number;
   interval: number;
   warmupRequest: boolean;

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -5,7 +5,8 @@ import { RequestConfiguration } from '../models/RequestConfiguration.model';
 export class ConfigService {
   readonly targetUrl = signal('');
   readonly method = signal('GET');
-  readonly customCode = signal('');
+  readonly headerName = signal('');
+  readonly headerValue = signal('');
   readonly requests = signal(20);
   readonly interval = signal(1);
   readonly warmupRequest = signal(true);
@@ -14,7 +15,8 @@ export class ConfigService {
     return {
       targetUrl: this.targetUrl(),
       method: this.method(),
-      customCode: this.customCode(),
+      headerName: this.headerName(),
+      headerValue: this.headerValue(),
       requests: this.requests(),
       interval: this.interval(),
       warmupRequest: this.warmupRequest(),
@@ -24,7 +26,8 @@ export class ConfigService {
   setConfiguration(config: RequestConfiguration): void {
     this.targetUrl.set(config.targetUrl);
     this.method.set(config.method);
-    this.customCode.set(config.customCode);
+    this.headerName.set(config.headerName);
+    this.headerValue.set(config.headerValue);
     this.requests.set(config.requests);
     this.interval.set(config.interval);
     this.warmupRequest.set(config.warmupRequest);

--- a/src/app/features/configuration/configuration.css
+++ b/src/app/features/configuration/configuration.css
@@ -57,8 +57,3 @@
   width: 100%;
 }
 
-.custom-editor textarea {
-  width: 100%;
-  min-height: 8rem;
-  font-family: monospace;
-}

--- a/src/app/features/configuration/configuration.html
+++ b/src/app/features/configuration/configuration.html
@@ -61,23 +61,29 @@
       </select>
     </div>
 
-    <!-- Custom JS Toggle -->
+    <!-- Custom Header Name -->
     <div class="form-field">
-      <button hlmBtn variant="outline" (click)="toggleCustom()">Custom JS</button>
+      <label hlmLabel for="header-name">Header Name</label>
+      <input
+        hlmInput
+        id="header-name"
+        type="text"
+        [(ngModel)]="headerName"
+        placeholder="X-Custom-Header"
+      />
     </div>
 
-    <!-- Custom JS Editor -->
-    @if (showCustom) {
-      <div class="form-field custom-editor">
-        <label hlmLabel for="custom-code">Request Code</label>
-        <textarea
-          hlmInput
-          id="custom-code"
-          [(ngModel)]="customCode"
-          placeholder="await http.request(method, targetUrl).toPromise();"
-        ></textarea>
-      </div>
-    }
+    <!-- Custom Header Value -->
+    <div class="form-field">
+      <label hlmLabel for="header-value">Header Value</label>
+      <input
+        hlmInput
+        id="header-value"
+        type="text"
+        [(ngModel)]="headerValue"
+        placeholder="my-value"
+      />
+    </div>
 
     <!-- Warm-up Request Toggle -->
     <div class="toggle-field">

--- a/src/app/features/configuration/configuration.ts
+++ b/src/app/features/configuration/configuration.ts
@@ -33,12 +33,11 @@ export class Configuration {
 
   targetUrl = this.config.targetUrl;
   method = this.config.method;
-  customCode = this.config.customCode;
+  headerName = this.config.headerName;
+  headerValue = this.config.headerValue;
   requests = this.config.requests;
   interval = this.config.interval;
   warmupRequest = this.config.warmupRequest;
-
-  showCustom = false;
 
   readonly isRunning = this.benchmark.isRunning;
   readonly currentRun = this.benchmark.currentRun;
@@ -57,13 +56,12 @@ export class Configuration {
   isValidConfiguration(): boolean {
     const url = this.targetUrl();
     const method = this.method().trim();
-    const code = this.customCode().trim();
     const reqs = this.requests();
     const int = this.interval();
 
     try {
       new URL(url);
-      return reqs > 0 && int > 0 && (method.length > 0 || code.length > 0);
+      return reqs > 0 && int > 0 && method.length > 0;
     } catch {
       return false;
     }
@@ -86,10 +84,6 @@ export class Configuration {
     if (ts) {
       this.benchmark.continueBenchmark(ts);
     }
-  }
-
-  toggleCustom(): void {
-    this.showCustom = !this.showCustom;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace `customCode` with `headerName` and `headerValue`
- remove custom JS feature and allow specifying a custom HTTP header

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68807afc7610832ca206d66f6aa6797b